### PR TITLE
Update SendAgent2 to enable message publishing

### DIFF
--- a/agrona/src/main/java/com/aeroncookbook/agrona/ringbuffer/SendAgent2.java
+++ b/agrona/src/main/java/com/aeroncookbook/agrona/ringbuffer/SendAgent2.java
@@ -36,7 +36,7 @@ public class SendAgent2 implements Agent
     @Override
     public int doWork()
     {
-        if (currentCountItem > sendCount)
+        if (currentCountItem < sendCount)
         {
             return 0;
         }


### PR DESCRIPTION
The condition `currentCountItem > sendCount` was always true, preventing SendAgent2 from publishing messages.